### PR TITLE
Fix loading extended modules in Java 9+.

### DIFF
--- a/src/main/java/net/minecraft/launchwrapper/LaunchClassLoader.java
+++ b/src/main/java/net/minecraft/launchwrapper/LaunchClassLoader.java
@@ -44,7 +44,7 @@ public class LaunchClassLoader extends URLClassLoader {
     private static File tempFolder = null;
 
     public LaunchClassLoader(URL[] sources) {
-        super(sources, null);
+        super(sources, getParentClassLoader());
         this.sources = new ArrayList<URL>(Arrays.asList(sources));
 
         // classloader exclusions
@@ -384,5 +384,16 @@ public class LaunchClassLoader extends URLClassLoader {
 
     public void clearNegativeEntries(Set<String> entriesToClear) {
         negativeResourceCache.removeAll(entriesToClear);
+    }
+
+    private static ClassLoader getParentClassLoader() {
+        if (!System.getProperty("java.version").startsWith("1.")) {
+            try {
+                return (ClassLoader) ClassLoader.class.getDeclaredMethod("getPlatformClassLoader").invoke(null);
+            } catch (Throwable t) {
+                LogWrapper.warning("No platform classloader: " + System.getProperty("java.version"));
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Fix https://github.com/sp614x/optifine/issues/2917.

@sp614x  Extended libraries and modules should be loaded by Platform Class Loader after Java 9.  
Codes are from https://github.com/MinecraftForge/Installer/blob/fe18a164b5ebb15b5f8f33f6a149cc224f446dc2/src/main/java/net/minecraftforge/installer/actions/PostProcessors.java#L287-L303